### PR TITLE
Addition of a script for writing lost particle last known locations/d…

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ Scripts/tools for working with various nuclear-related tools and MOAB/iTaps base
 Tools
 -----
 
-- `lostparticles/` contains `mklostvis.pl` which parses MCNP output file to create a CUBIT .jou file for visualizing lost particle locations.
+- `lostparticles/` contains
+   - `mklostvis.pl` which parses MCNP output file to create a CUBIT .jou file for visualizing lost particle locations.
+   - `lostparts2mesh.py` which parses an MCNP output file to create a MOAB mesh file for visualizing lost particle locations.
 - `mesh2mcnp/` contains `mesh2mcnp.py` which creates an MCNP input from a (small) tet mesh.
 - `ptracviz/` contains `ptracviz.cpp` which takes an MCNP ptrac file and converts it to a journal file for visualizing tracks in CUBIT.
 - `tetmesh2points/` contains the script `tet_vals_and_centroids.py`, which loads a MOAB mesh file (e.g. .vtk or .h5m file), calculates the centroid of any tetrahedron elements, and writes the x,y,z plus tally values and errors to a file.

--- a/lostparticles/README.rst
+++ b/lostparticles/README.rst
@@ -3,3 +3,12 @@ lostparticles
 Script last updated ~10-2009
 - Original author: Tim Bohm
 - Perl script to read MCNP output file for lost particle info and create a CUBIT .jou file to visualize
+
+lostparts2mesh
+==============
+- Original author: Patrick Shriwise
+- python script to read an MCNP output file lost particle last known locations/directions and write them to mesh using either pymoab or iMesh
+    
+     - locations: vertices in the mesh
+     - directions: vector tag on the vertices
+  

--- a/lostparticles/lostparts2mesh.py
+++ b/lostparticles/lostparts2mesh.py
@@ -1,0 +1,67 @@
+
+import sys
+import numpy as np
+
+uvw_tag_name = "RAY_DIR"
+output_filename = "lost_particle_locations.h5m"
+#open the mcnp output file
+file = open(sys.argv[1], 'rb')
+#start with five lines in our line_cache
+line_cache = [file.readline(),file.readline(),file.readline(),file.readline(),file.readline(),file.readline()]
+#dictionary for holding lost particle info
+lost_part_dict = {}
+for line in file:
+    #add line to cache
+    line_cache.append(line)    
+    #line_cache should always be size six here
+    assert(7 == len(line_cache))
+    #check for lost particle indicator substring
+    if "no intersection found in subroutine track" in line_cache[0]:
+        #lost particle add last known location and number to dictionary
+        #need to adjust parsing if more than 100 are lost
+        split_key_line = line_cache[0].split()
+        key = split_key_line[4] if len(lost_part_dict) < 100 else split_key_line[3].split('.')[-1]
+        xyz = line_cache[-2].split()[2:5]
+        uvw = line_cache[-1].split()[3:6]
+        #add to lost particle dict
+        lost_part_dict[key] = xyz + uvw
+    #remove line from cache
+    line_cache.pop(0)
+    
+#print out some info for user verification
+print("Found" ,len(lost_part_dict), "lost particles.")
+print(lost_part_dict["no"])
+
+#write the data to a mesh
+try:
+    from pymoab import core,types
+    mbi = core.Core()
+    print("Using pymoab to generate mesh file....")
+    ray_tag_handle = mbi.tag_get_handle(uvw_tag_name, 3, types.MB_TYPE_DOUBLE, True)
+    #vertices to the MOAB instance
+    verts = mbi.create_vertices(np.array([float(i) for l in lost_part_dict.values() for i in l[:3]],dtype='float64'))
+    #and now tag the verices with the lost particle directions
+    mbi.tag_set_data(ray_tag_handle, verts, np.array([float(i) for l in lost_part_dict.values() for i in l[3:6]]))
+    # write the vertex locations to file
+    mbi.write_file(output_filename)
+    print("Done.")
+    sys.exit()
+except ImportError:
+    pass
+try:
+    from itaps.iMesh import Mesh
+    mbi = Mesh()
+    print("Using iMesh to generate mesh file.")        
+    #create vertices for each lost particle location
+    vertices = []
+    for lost_part in lost_part_dict.values():
+        vertices.append(mbi.createVtx([float(i) for i in lost_part[:3]]))
+        #create a tag for the direction of lost particles
+    ray_tag_handle = mbi.createTag(uvw_tag_name,3,'d')
+    for vert,lost_part in zip(vertices,lost_part_dict.values()):
+        ray_tag_handle[vert] = [float(i) for i in lost_part[3:6]]
+    mbi.save(output_filename)
+    print("Done.")
+    sys.exit()
+except ImportError:
+    print("No supported mesh modules found. Please install pymoab or iMesh")

--- a/lostparticles/lostparts2mesh.py
+++ b/lostparticles/lostparts2mesh.py
@@ -5,7 +5,7 @@ import argparse
 
 parser = argparse.ArgumentParser()
 parser.add_argument("input_file", help="MCNP outp file to parse for lost particles")
-parser.add_argument("--vector-length", help="Sets length of ray vectors. (Default  is 10)", default= 10.)
+parser.add_argument("--vector-length", help="Sets length of ray vectors. (Default  is 10)", type=float, default= 10.)
 args = parser.parse_args()
 
 uvw_tag_name = "RAY_DIR"
@@ -36,7 +36,6 @@ for line in file:
     
 #print out some info for user verification
 print("Found" ,len(lost_part_dict), "lost particles.")
-print(lost_part_dict["no"])
 
 #write the data to a mesh
 try:

--- a/lostparticles/lostparts2mesh.py
+++ b/lostparticles/lostparts2mesh.py
@@ -1,11 +1,17 @@
 
 import sys
 import numpy as np
+import argparse
+
+parser = argparse.ArgumentParser()
+parser.add_argument("input_file", help="MCNP outp file to parse for lost particles")
+parser.add_argument("--vector-length", help="Sets length of ray vectors. (Default  is 10)", default= 10.)
+args = parser.parse_args()
 
 uvw_tag_name = "RAY_DIR"
 output_filename = "lost_particle_locations.h5m"
 #open the mcnp output file
-file = open(sys.argv[1], 'rb')
+file = open(args.input_file, 'rb')
 #start with five lines in our line_cache
 line_cache = [file.readline(),file.readline(),file.readline(),file.readline(),file.readline(),file.readline()]
 #dictionary for holding lost particle info
@@ -41,7 +47,7 @@ try:
     #vertices to the MOAB instance
     verts = mbi.create_vertices(np.array([float(i) for l in lost_part_dict.values() for i in l[:3]],dtype='float64'))
     #and now tag the verices with the lost particle directions
-    mbi.tag_set_data(ray_tag_handle, verts, np.array([float(i) for l in lost_part_dict.values() for i in l[3:6]]))
+    mbi.tag_set_data(ray_tag_handle, verts, np.array([args.vector_length*float(i) for l in lost_part_dict.values() for i in l[3:6]]))
     # write the vertex locations to file
     mbi.write_file(output_filename)
     print("Done.")
@@ -59,7 +65,7 @@ try:
         #create a tag for the direction of lost particles
     ray_tag_handle = mbi.createTag(uvw_tag_name,3,'d')
     for vert,lost_part in zip(vertices,lost_part_dict.values()):
-        ray_tag_handle[vert] = [float(i) for i in lost_part[3:6]]
+        ray_tag_handle[vert] = [args.vector_length*float(i) for i in lost_part[3:6]]
     mbi.save(output_filename)
     print("Done.")
     sys.exit()


### PR DESCRIPTION
Addition of a convenience script for writing last known lost particle locations to a moab mesh. This will write a .h5m file with the last known locations as vertices and the associated direction with that location as a vector tag of double, size 3. 

The result is a moab .h5m file which can be converted to a .vtk file and viewed in visit/paraview on top of mesh entities with vector data of the lost particles in place.
