### PR TITLE
Updates mklostvis to handle more than 999 lost particles and updates README

### DIFF
--- a/lostparticles/README.rst
+++ b/lostparticles/README.rst
@@ -1,8 +1,7 @@
-lostparticles
+mklostvis
 =============
-Script last updated ~10-2009
 - Original author: Tim Bohm
-- Perl script to read MCNP output file for lost particle info and create a CUBIT .jou file to visualize
+- Perl script to read an MCNP output file for lost particle info and create a CUBIT/Trelis .jou file to visualize
 
 lostparts2mesh
 ==============


### PR DESCRIPTION
updates mklostvis since MCNP lost particle output only allows 3 characters for the lost particle number and repeats lost particle number labels when run in parallel